### PR TITLE
Create a cacheable version of predict_rc

### DIFF
--- a/UI/BondRecommender/data_loader.py
+++ b/UI/BondRecommender/data_loader.py
@@ -1,6 +1,8 @@
 import os
-import pandas as pd
 import datetime
+from functools import lru_cache
+
+import pandas as pd
 
 DATA_DIR=os.getenv(
     'DATA_DIR', 
@@ -114,3 +116,14 @@ class MultipleDayDataLoader(object):
             else:
                 cohort_conditions = cohort_conditions & condition
         return self.data.loc[cohort_conditions]
+
+# Load once and cache for efficiency
+
+@lru_cache(maxsize=16)
+def get_single_day_data(*args, **kwargs):
+    return SingleDayDataLoader(*args, **kwargs)
+
+@lru_cache(maxsize=16)
+def get_multi_day_data(*args, **kwargs):
+    return MultipleDayDataLoader(*args, **kwargs)
+

--- a/UI/BondRecommender/prediction_models.py
+++ b/UI/BondRecommender/prediction_models.py
@@ -1,8 +1,12 @@
+import warnings
+from functools import lru_cache
+
 import pandas as pd
 import numpy as np
 from sklearn.linear_model import LinearRegression
-from BondRecommender.data_loader import MultipleDayDataLoader
-import warnings
+
+from BondRecommender.data_loader import get_single_day_data, get_multi_day_data
+
 warnings.filterwarnings("ignore")
 
 # ----------------------------- Functions -------------------------------
@@ -151,3 +155,13 @@ def predict_rc(multiple_day_data, date, isins):
     bonds.rename(columns={'score': 'rich/cheap'}, inplace=True)
 
     return bonds
+
+
+@lru_cache(maxsize=1000)
+def predict_single_rc(date, isin):
+    # Since lru_cache doesn't work with list inputs (they're not hashable), 
+    # we add a new function with cacheable inputs that wraps predict_rc 
+    # Note: calling this function many times in a row is slower than calling predict_rc with a batch
+    isins = [isin]
+    return predict_rc(get_multi_day_data(), date=date, isins=isins)
+


### PR DESCRIPTION
@naotominakawa , @kkzarsj , @addyying , @elinsun , @jkhasin 

This PR makes minimal changes necessary to speed up the UI by caching rich/cheap predictions. 

Note: The way I have implemented it is now _slower_ upon first access (takes around a minute), since it makes 10 separate calls to `predict_rc`, but, once done, it's very fast to reload the page / provide feedback. So, if we run our test bond once before the demo, we should be good. But it's worth revisiting and doing a more thorough job at optimizing this code.